### PR TITLE
moved to nw-builder and fixed incorrect version selection

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2014 macco
  *
  * This program is free software; you can redistribute it and/or
@@ -20,9 +20,10 @@
 module.exports = function(grunt) {
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
-        nodewebkit: {
+        nwjs: {
             options: {
                 build_dir: './dist',
+                version: "0.12.3",
                 // choose what platforms to compile for here
                 mac: true,
                 win: true,
@@ -33,6 +34,6 @@ module.exports = function(grunt) {
         }
     })
 
-    grunt.loadNpmTasks('grunt-node-webkit-builder');
-    grunt.registerTask('default', ['nodewebkit']);
+    grunt.loadNpmTasks('grunt-nw-builder');
+    grunt.registerTask('default', ['nwjs']);
 };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "Akiee",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "description": "Akiee is a task management for hackers. It is based on markdown to structure your tasks and projects. It can be used on Linux, Mac ond Windows. Clients for android and iOS are planned - so long files can be edited with every text editor.",
   "author": "Marco Laspe",
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-node-webkit-builder": "^0.3.0"
+    "grunt-nw-builder": "^2.0.0"
   }
 }


### PR DESCRIPTION
The actual version did not build for me. So I switched to nw-builder as recommended and fixed the version number in order to overrule the automatic detection, which tried to select 0.13.0-alpha and failed as there are no builds available yet.