### PR TITLE
enabled Cut&Paste on OSX

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -21,6 +21,12 @@
             cssUrl = ubuntuExternalCss;
         } else if (process.platform === 'darwin') {
             cssUrl = osxExternalCss;
+            var gui = require('nw.gui');
+            var mb = new gui.Menu({type: 'menubar'});
+            mb.createMacBuiltin('Akiee', {
+                hideEdit: false,
+            });
+            gui.Window.get().menu = mb;
         } else if (process.platform === 'win32') {
             cssUrl = winExternalCss;
         }


### PR DESCRIPTION
As discussed in https://github.com/nwjs/nw.js/issues/1955 Cut&Paste (and other edit options) is not available on OSX by default, which is extremely annoying and renders working with Akiee very difficult. It effects every text field, e.g. the Details field and even more critical, the Markdown Editor.

This fix enables Edit Menu, which brings back all expected text edit functionality on OSX.